### PR TITLE
Fix pdftk.rb and use Homebrew conventions

### DIFF
--- a/pdftk.rb
+++ b/pdftk.rb
@@ -1,23 +1,22 @@
-class PkgExtract < CurlDownloadStrategy
-  def stage
-    url_sha256 = Digest::SHA256.hexdigest(url)
-    safe_system '/usr/bin/xar', '-xf', Dir["#{HOMEBREW_CACHE}/downloads/#{url_sha256}--*"].first
-    Dir.mkdir "pdftk"
-    safe_system "tar -xf *.pkg/Payload -C pdftk/."
-  end
-end
+# typed: false
+# frozen_string_literal: true
 
+# Pdftk formula
 class Pdftk < Formula
+  FILENAME = 'pdftk_server-2.02-mac_osx-10.11-setup.pkg'
   homepage 'http://www.pdflabs.com/tools/pdftk-server'
-  url 'http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg',
-    :using => PkgExtract
+  url "http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/#{FILENAME}"
   sha256 'c33cf95151e477953cd57c1ea9c99ebdc29d75f4c9af0d5f947b385995750b0c'
 
   def install
-    prefix.install Dir["pdftk/*"]
+    # Outputs it to pdftk.pkg/*
+    safe_system '/usr/bin/xar', '-xf', FILENAME
+    Dir.mkdir 'tmp'
+    safe_system 'tar -xf pdftk.pkg/Payload -C tmp/.'
+    prefix.install Dir['tmp/*']
   end
 
   test do
-    system "#{bin}/pdftk --version"
+    system "#{bin}/pdftk", '--version'
   end
 end

--- a/pdftk.rb
+++ b/pdftk.rb
@@ -1,16 +1,9 @@
-require 'formula'
-
 class PkgExtract < CurlDownloadStrategy
   def stage
-
- #   safe_system '/usr/bin/xar', '-xf', '/Users/olehartvigsen/Library/Caches/Homebrew/downloads/c94247ce6a067cee85cc03cf89c827f31b715fb26c6fe748cf9e1e2a61e667d9--pdftk_server-2.02-mac_osx-10.11-setup.pkg'
-    safe_system '/usr/bin/xar', '-xf', HOMEBREW_CACHE/'downloads/#{url_sha256}--*'
-
-    
-    
-    chdir
-    safe_system 'mv *.pkg/Payload Payload.gz'
-    safe_system 'ls | grep -v Payload | xargs rm -r'
+    url_sha256 = Digest::SHA256.hexdigest(url)
+    safe_system '/usr/bin/xar', '-xf', Dir["#{HOMEBREW_CACHE}/downloads/#{url_sha256}--*"].first
+    Dir.mkdir "pdftk"
+    safe_system "tar -xf *.pkg/Payload -C pdftk/."
   end
 end
 
@@ -20,10 +13,8 @@ class Pdftk < Formula
     :using => PkgExtract
   sha256 'c33cf95151e477953cd57c1ea9c99ebdc29d75f4c9af0d5f947b385995750b0c'
 
-
-
   def install
-    safe_system "pax --insecure -rz -f Payload.gz -s ',./bin,#{bin},' -s ',./man,#{man},' -s ',./lib,#{lib},' -s ',./license_gpl_pdftk,#{prefix}/LICENSE,' -s ',./,#{prefix}/README/,'"
+    prefix.install Dir["pdftk/*"]
   end
 
   test do


### PR DESCRIPTION
- Removes commented code
- Uses Homebrew conventions to remove duplicated effort (xargs and rm -rf)
- Uses builtin mechanisms for installing files into right location
- Fixes broken reference to `url_sha256`